### PR TITLE
Added a Websocket endpoint for the logs

### DIFF
--- a/config/config/pom.xml
+++ b/config/config/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>at.wrk.coceso-config</groupId>
         <artifactId>coceso-config-base</artifactId>
-        <version>2.8.6-SNAPSHOT</version>
+        <version>2.8.7-SNAPSHOT</version>
     </parent>
 
     <artifactId>coceso-config</artifactId>

--- a/config/db/pom.xml
+++ b/config/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>at.wrk.coceso-config</groupId>
         <artifactId>coceso-config-base</artifactId>
-        <version>2.8.6-SNAPSHOT</version>
+        <version>2.8.7-SNAPSHOT</version>
     </parent>
 
     <artifactId>coceso-config-db</artifactId>

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>at.wrk.coceso</groupId>
         <artifactId>base</artifactId>
-        <version>2.8.6-SNAPSHOT</version>
+        <version>2.8.7-SNAPSHOT</version>
     </parent>
 
     <groupId>at.wrk.coceso-config</groupId>

--- a/config/tomcat10/pom.xml
+++ b/config/tomcat10/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>at.wrk.coceso-config</groupId>
         <artifactId>coceso-config-base</artifactId>
-        <version>2.8.6-SNAPSHOT</version>
+        <version>2.8.7-SNAPSHOT</version>
     </parent>
 
     <artifactId>coceso-config-tomcat10</artifactId>

--- a/config/web/pom.xml
+++ b/config/web/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>at.wrk.coceso-config</groupId>
         <artifactId>coceso-config-base</artifactId>
-        <version>2.8.6-SNAPSHOT</version>
+        <version>2.8.7-SNAPSHOT</version>
     </parent>
 
     <artifactId>coceso-config-web</artifactId>

--- a/geocode/geocode-impl/pom.xml
+++ b/geocode/geocode-impl/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>at.wrk.geocode</groupId>
         <artifactId>geocode-base</artifactId>
-        <version>2.8.6-SNAPSHOT</version>
+        <version>2.8.7-SNAPSHOT</version>
     </parent>
 
     <artifactId>geocode-impl</artifactId>

--- a/geocode/geocode/pom.xml
+++ b/geocode/geocode/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>at.wrk.geocode</groupId>
         <artifactId>geocode-base</artifactId>
-        <version>2.8.6-SNAPSHOT</version>
+        <version>2.8.7-SNAPSHOT</version>
     </parent>
 
     <artifactId>geocode</artifactId>

--- a/geocode/pom.xml
+++ b/geocode/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>at.wrk.coceso</groupId>
     <artifactId>base</artifactId>
-    <version>2.8.6-SNAPSHOT</version>
+    <version>2.8.7-SNAPSHOT</version>
   </parent>
 
   <groupId>at.wrk.geocode</groupId>

--- a/main/db/pom.xml
+++ b/main/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>at.wrk.coceso</groupId>
         <artifactId>main</artifactId>
-        <version>2.8.6-SNAPSHOT</version>
+        <version>2.8.7-SNAPSHOT</version>
     </parent>
 
     <artifactId>coceso-db</artifactId>

--- a/main/entity/pom.xml
+++ b/main/entity/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>at.wrk.coceso</groupId>
         <artifactId>main</artifactId>
-        <version>2.8.6-SNAPSHOT</version>
+        <version>2.8.7-SNAPSHOT</version>
     </parent>
 
     <artifactId>coceso-entity</artifactId>

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -8,12 +8,12 @@
   <parent>
     <groupId>at.wrk.coceso</groupId>
     <artifactId>base</artifactId>
-    <version>2.8.6-SNAPSHOT</version>
+    <version>2.8.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>main</artifactId>
   <packaging>pom</packaging>
-  <version>2.8.6-SNAPSHOT</version>
+  <version>2.8.7-SNAPSHOT</version>
   <name>Coceso Main App</name>
 
   <modules>

--- a/main/resources/ReleaseNotes/2.8.7.md
+++ b/main/resources/ReleaseNotes/2.8.7.md
@@ -1,0 +1,13 @@
+## Version 2.8.7
+
+Release 2.8.7 (Snapshot) — Kurzüberblick
+
+- Neuer WebSocket‑Publisher für Log‑Einträge: Logeinträge werden nach dem Persistieren per STOMP an `/topic/log/{concernId}` gesendet.
+- Änderungen in `LogServiceImpl` und neue Komponente `LogWebSocketPublisher` (nicht sequenziert; folgt evtl. in späteren Versionen).
+- Versionsnummern in den POMs auf `2.8.7-SNAPSHOT` erhöht.
+
+Hinweis:
+- Die WebSocket‑Endpoint ist `/data/socket` (STOMP). Zur Verbindung muss eine gültige Sitzung (`JSESSIONID`) vorhanden sein — Login über `/client/login` erforderlich.
+- Die Veröffentlichung verwendet aktuell das `LogEntry` JSON‑Format (gleich dem REST‑Endpoint `/data/log/getLast/{count}`); falls nötig, kann eine `SequencedResponse`‑Hülle ergänzt werden.
+
+Danksagung: Debug‑Logs halfen beim lokalen Verifizieren der Verbindung.

--- a/main/resources/ReleaseNotes/2.8.7.md
+++ b/main/resources/ReleaseNotes/2.8.7.md
@@ -3,11 +3,9 @@
 Release 2.8.7 (Snapshot) — Kurzüberblick
 
 - Neuer WebSocket‑Publisher für Log‑Einträge: Logeinträge werden nach dem Persistieren per STOMP an `/topic/log/{concernId}` gesendet.
-- Änderungen in `LogServiceImpl` und neue Komponente `LogWebSocketPublisher` (nicht sequenziert; folgt evtl. in späteren Versionen).
+- Änderungen in `LogServiceImpl` und neue Komponente `LogWebSocketPublisher`
 - Versionsnummern in den POMs auf `2.8.7-SNAPSHOT` erhöht.
 
 Hinweis:
 - Die WebSocket‑Endpoint ist `/data/socket` (STOMP). Zur Verbindung muss eine gültige Sitzung (`JSESSIONID`) vorhanden sein — Login über `/client/login` erforderlich.
-- Die Veröffentlichung verwendet aktuell das `LogEntry` JSON‑Format (gleich dem REST‑Endpoint `/data/log/getLast/{count}`); falls nötig, kann eine `SequencedResponse`‑Hülle ergänzt werden.
-
-Danksagung: Debug‑Logs halfen beim lokalen Verifizieren der Verbindung.
+- Die Veröffentlichung verwendet aktuell das `LogEntry` JSON‑Format (gleich dem REST‑Endpoint `/data/log/getLast/{count}`)

--- a/main/service-impl/pom.xml
+++ b/main/service-impl/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>at.wrk.coceso</groupId>
         <artifactId>main</artifactId>
-        <version>2.8.6-SNAPSHOT</version>
+        <version>2.8.7-SNAPSHOT</version>
     </parent>
 
     <artifactId>coceso-service-impl</artifactId>

--- a/main/service-impl/src/main/java/at/wrk/coceso/service/impl/LogServiceImpl.java
+++ b/main/service-impl/src/main/java/at/wrk/coceso/service/impl/LogServiceImpl.java
@@ -47,6 +47,9 @@ class LogServiceImpl implements LogService {
     @Autowired
     private LogRepository logRepository;
 
+    @Autowired(required = false)
+    private LogWebSocketPublisher logWebSocketPublisher;
+
     private final AuthenticatedUserProvider authenticatedUserProvider;
 
     @Autowired
@@ -56,17 +59,17 @@ class LogServiceImpl implements LogService {
 
     @Override
     public void logAuto(final LogEntryType type, final Concern concern, final Changes changes) {
-        logRepository.saveAndFlush(new LogEntry(getUser(), type, type.name(), concern, null, null, null, null, changes));
+        saveAndPublish(new LogEntry(getUser(), type, type.name(), concern, null, null, null, null, changes));
     }
 
     @Override
     public void logAuto(final LogEntryType type, final Concern concern, final Unit unit, final Incident incident, final Changes changes) {
-        logRepository.saveAndFlush(new LogEntry(getUser(), type, type.name(), concern, unit, incident, null, null, changes));
+        saveAndPublish(new LogEntry(getUser(), type, type.name(), concern, unit, incident, null, null, changes));
     }
 
     @Override
     public void logAuto(final LogEntryType type, final Concern concern, final Unit unit, final Incident incident, final TaskState state) {
-        logRepository.saveAndFlush(new LogEntry(getUser(), type, type.name(), concern, unit, incident, null, state, null));
+        saveAndPublish(new LogEntry(getUser(), type, type.name(), concern, unit, incident, null, state, null));
     }
 
     @Override
@@ -76,22 +79,22 @@ class LogServiceImpl implements LogService {
             final Incident incident,
             final TaskState state,
             final Changes changes) {
-        logRepository.saveAndFlush(new LogEntry(getUser(), type, type.name(), concern, unit, incident, null, state, changes));
+        saveAndPublish(new LogEntry(getUser(), type, type.name(), concern, unit, incident, null, state, changes));
     }
 
     @Override
     public void logAuto(final LogEntryType type, final Concern concern, final Patient patient, final Changes changes) {
-        logRepository.saveAndFlush(new LogEntry(getUser(), type, type.name(), concern, null, null, patient, null, changes));
+        saveAndPublish(new LogEntry(getUser(), type, type.name(), concern, null, null, patient, null, changes));
     }
 
     @Override
     public void logAuto(final LogEntryType type, final Concern concern, final Incident incident, final Patient patient) {
-        logRepository.saveAndFlush(new LogEntry(getUser(), type, type.name(), concern, null, incident, patient, null, null));
+        saveAndPublish(new LogEntry(getUser(), type, type.name(), concern, null, incident, patient, null, null));
     }
 
     @Override
     public void logCustom(final String text, final Concern concern, final Unit unit, final Incident incident) {
-        logRepository.saveAndFlush(new LogEntry(getUser(), LogEntryType.CUSTOM, text, concern, unit, incident, null, null, null));
+        saveAndPublish(new LogEntry(getUser(), LogEntryType.CUSTOM, text, concern, unit, incident, null, null, null));
     }
 
     @Override
@@ -164,6 +167,18 @@ class LogServiceImpl implements LogService {
     @Override
     public void updateForRemoval(final Unit unit) {
         logRepository.updateForRemoval(unit);
+    }
+
+    private LogEntry saveAndPublish(final LogEntry entry) {
+        LogEntry saved = logRepository.saveAndFlush(entry);
+        try {
+            if (logWebSocketPublisher != null && saved != null) {
+                logWebSocketPublisher.publish(saved.getConcern(), saved);
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to publish log entry via websocket", e);
+        }
+        return saved;
     }
 
 

--- a/main/service-impl/src/main/java/at/wrk/coceso/service/impl/LogWebSocketPublisher.java
+++ b/main/service-impl/src/main/java/at/wrk/coceso/service/impl/LogWebSocketPublisher.java
@@ -1,0 +1,45 @@
+package at.wrk.coceso.service.impl;
+
+import at.wrk.coceso.entity.Concern;
+import at.wrk.coceso.entity.LogEntry;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LogWebSocketPublisher {
+    private static final Logger LOG = LoggerFactory.getLogger(LogWebSocketPublisher.class);
+
+    private final SimpMessagingTemplate messaging;
+
+    @Autowired(required = false)
+    public LogWebSocketPublisher(SimpMessagingTemplate messaging) {
+        this.messaging = messaging;
+    }
+
+    public void publish(final Concern concern, final LogEntry entry) {
+        if (messaging == null) {
+            LOG.debug("SimpMessagingTemplate not available; skipping websocket publish for log");
+            return;
+        }
+
+        if (concern == null) {
+            LOG.debug("No concern on LogEntry; skipping websocket publish");
+            return;
+        }
+
+        try {
+            if (messaging == null) {
+                LOG.debug("SimpMessagingTemplate is not available; skipping publish");
+                return;
+            }
+            String topic = String.format("/topic/log/%d", concern.getId());
+            LOG.debug("Publishing LogEntry to topic {}: {}", topic, entry);
+            messaging.convertAndSend(topic, entry);
+        } catch (Exception e) {
+            LOG.warn("Failed to publish LogEntry to websocket", e);
+        }
+    }
+}

--- a/main/service/pom.xml
+++ b/main/service/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>at.wrk.coceso</groupId>
         <artifactId>main</artifactId>
-        <version>2.8.6-SNAPSHOT</version>
+        <version>2.8.7-SNAPSHOT</version>
     </parent>
 
     <artifactId>coceso-service</artifactId>

--- a/main/taglib/pom.xml
+++ b/main/taglib/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>at.wrk.coceso</groupId>
         <artifactId>main</artifactId>
-        <version>2.8.6-SNAPSHOT</version>
+        <version>2.8.7-SNAPSHOT</version>
     </parent>
 
     <artifactId>coceso-taglib</artifactId>

--- a/main/view/pom.xml
+++ b/main/view/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>at.wrk.coceso</groupId>
         <artifactId>main</artifactId>
-        <version>2.8.6-SNAPSHOT</version>
+        <version>2.8.7-SNAPSHOT</version>
     </parent>
 
     <artifactId>coceso-view</artifactId>

--- a/plugin/alarm-text/pom.xml
+++ b/plugin/alarm-text/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>coceso-plugins-base</artifactId>
         <groupId>at.wrk.coceso-plugins</groupId>
-        <version>2.8.6-SNAPSHOT</version>
+        <version>2.8.7-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/plugin/geobroker/pom.xml
+++ b/plugin/geobroker/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>coceso-plugins-base</artifactId>
         <groupId>at.wrk.coceso-plugins</groupId>
-        <version>2.8.6-SNAPSHOT</version>
+        <version>2.8.7-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/plugin/gmaps/pom.xml
+++ b/plugin/gmaps/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>at.wrk.coceso-plugins</groupId>
         <artifactId>coceso-plugins-base</artifactId>
-        <version>2.8.6-SNAPSHOT</version>
+        <version>2.8.7-SNAPSHOT</version>
     </parent>
 
     <artifactId>coceso-gmaps</artifactId>

--- a/plugin/niu/pom.xml
+++ b/plugin/niu/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>at.wrk.coceso-plugins</groupId>
         <artifactId>coceso-plugins-base</artifactId>
-        <version>2.8.6-SNAPSHOT</version>
+        <version>2.8.7-SNAPSHOT</version>
     </parent>
 
     <artifactId>coceso-niu</artifactId>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>at.wrk.coceso</groupId>
     <artifactId>base</artifactId>
-    <version>2.8.6-SNAPSHOT</version>
+      <version>2.8.7-SNAPSHOT</version>
   </parent>
 
   <groupId>at.wrk.coceso-plugins</groupId>

--- a/plugin/radio/pom.xml
+++ b/plugin/radio/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>at.wrk.coceso-plugins</groupId>
         <artifactId>coceso-plugins-base</artifactId>
-        <version>2.8.6-SNAPSHOT</version>
+        <version>2.8.7-SNAPSHOT</version>
     </parent>
 
     <artifactId>coceso-radio</artifactId>

--- a/plugin/vienna/pom.xml
+++ b/plugin/vienna/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>at.wrk.coceso-plugins</groupId>
         <artifactId>coceso-plugins-base</artifactId>
-        <version>2.8.6-SNAPSHOT</version>
+        <version>2.8.7-SNAPSHOT</version>
     </parent>
 
     <artifactId>coceso-vienna</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>at.wrk.coceso</groupId>
     <artifactId>base</artifactId>
     <packaging>pom</packaging>
-    <version>2.8.6-SNAPSHOT</version>
+    <version>2.8.7-SNAPSHOT</version>
     <name>Coceso Parent POM</name>
 
     <properties>


### PR DESCRIPTION
## Version 2.8.7

Release 2.8.7 (Snapshot) — Kurzüberblick

- Neuer WebSocket‑Publisher für Log‑Einträge: Logeinträge werden nach dem Persistieren per STOMP an `/topic/log/{concernId}` gesendet.
- Änderungen in `LogServiceImpl` und neue Komponente `LogWebSocketPublisher`
- Versionsnummern in den POMs auf `2.8.7-SNAPSHOT` erhöht.

Hinweis:
- Die WebSocket‑Endpoint ist `/data/socket` (STOMP). Zur Verbindung muss eine gültige Sitzung (`JSESSIONID`) vorhanden sein — Login über `/client/login` erforderlich.
- Die Veröffentlichung verwendet aktuell das `LogEntry` JSON‑Format (gleich dem REST‑Endpoint `/data/log/getLast/{count}`)